### PR TITLE
Fix Clientside NullPointerException when Receiving packet

### DIFF
--- a/src/main/java/io/github/lumine1909/f3f4perms/FoliaUtil.java
+++ b/src/main/java/io/github/lumine1909/f3f4perms/FoliaUtil.java
@@ -14,4 +14,12 @@ public class FoliaUtil {
             Bukkit.getScheduler().runTask(plugin, runnable);
         }
     }
+
+    public static void runTaskLater(Plugin plugin, Player player, Runnable runnable, long delay) {
+        if (FoliaScheduler.isFolia()) {
+            FoliaScheduler.getRegionScheduler().runDelayed(plugin, player.getLocation(), task -> runnable.run(), delay);
+        } else {
+            Bukkit.getScheduler().runTaskLater(plugin, runnable, delay);
+        }
+    }
 }

--- a/src/main/java/io/github/lumine1909/f3f4perms/LuckPermsHook.java
+++ b/src/main/java/io/github/lumine1909/f3f4perms/LuckPermsHook.java
@@ -17,7 +17,7 @@ public class LuckPermsHook {
         LuckPerms luckPerms = LuckPermsProvider.get();
         subscription = luckPerms.getEventBus().subscribe(ContextUpdateEvent.class, e -> {
             if (e.getSubject() instanceof Player) {
-                plugin.updateOpLevel((Player) e.getSubject(), false);
+                FoliaUtil.runTaskLater(plugin, (Player) e.getSubject(), () -> plugin.updateOpLevel((Player) e.getSubject(), false), 1L);
             }
         });
         plugin.getLogger().info("Successfully hooked into LuckPerms!");


### PR DESCRIPTION
This was done by delaying the luckperms op hook by one tick to ensure the level packet arrived first. For that a additional runTaskLater method was intoduced in FoliaUtil.

This bug was quite unreproducable and sometimes it worked fine, sometimes not.

Fixes #5.